### PR TITLE
Consume PokeBattler.com API for additional Raid Boss information

### DIFF
--- a/Helpers/InvocationHelper.cs
+++ b/Helpers/InvocationHelper.cs
@@ -90,6 +90,22 @@ namespace PoGoChatbot.Helpers
         private static async Task HandleRaidBossesInvocation(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             await turnContext.SendActivityAsync(MessageFactory.Text(Constants.RaidBossesMessage), cancellationToken);
+
+            var tierFiveRaids = await PokeBattlerApiHelper.GetRaids(tier: 5);
+            if (tierFiveRaids.All(raid => !string.IsNullOrEmpty(raid.Article?.InfographicURL)))
+            {
+                bool pluralize = tierFiveRaids.Count() > 1;
+
+                await turnContext.SendActivityAsync(MessageFactory.Text($"Here's {(pluralize ? "infographics" : " an infographic")} with details about the current tier-five raid {(pluralize ? "bosses" : "boss")}, courtesy of PokeBattler."));
+
+                await turnContext.SendActivitiesAsync(
+                    tierFiveRaids
+                    .Select(raid =>
+                        MessageFactory.Attachment(new Attachment("image/png", raid.Article.InfographicURL)) as IActivity
+                    )
+                    .ToArray()
+                );
+            }
         }
 
         private static async Task HandleTypeLookupInvocation(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)

--- a/Helpers/InvocationHelper.cs
+++ b/Helpers/InvocationHelper.cs
@@ -117,7 +117,7 @@ namespace PoGoChatbot.Helpers
             var pokemon = await PoGoApiHelper.GetPokemonType(searchTerm);
             if (pokemon != null)
             {
-                var typeOrTypes = pokemon.Type.Length == 1 ? "type" : "types";
+                var typeOrTypes = pokemon.Type.Count == 1 ? "type" : "types";
                 var messageText = $"{pokemon.Name} has the {typeOrTypes} {string.Join(" and ", pokemon.Type)}. That means it is:\n\n";
 
                 var doubleResistantAgainst = pokemon.MatchupsForType.Where(pair => pair.Value == Constants.Numeric.DOUBLE_RESISTANT).Select(pair => pair.Key);

--- a/Helpers/PoGoApiHelper.cs
+++ b/Helpers/PoGoApiHelper.cs
@@ -8,7 +8,7 @@ using PoGoChatbot.Models;
 
 namespace PoGoChatbot.Helpers
 {
-    public class PoGoApiHelper
+    public static class PoGoApiHelper
     {
         private static readonly HttpClient poGoApiClient = new HttpClient { BaseAddress = new Uri("https://pogoapi.net/") };
         private static List<Pokemon> pokemonList = new List<Pokemon>();

--- a/Helpers/PoGoApiHelper.cs
+++ b/Helpers/PoGoApiHelper.cs
@@ -44,7 +44,7 @@ namespace PoGoChatbot.Helpers
             return matchedPokemon;
         }
 
-        public static MatchupsForType GetMatchupsForType(string[] pokemonTypes)
+        public static MatchupsForType GetMatchupsForType(List<string> pokemonTypes)
         {
             return pokemonTypes
                 .Select(pokemonType =>

--- a/Helpers/PokeBattlerApiHelper.cs
+++ b/Helpers/PokeBattlerApiHelper.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using PoGoChatbot.Models;
+
+namespace PoGoChatbot.Helpers
+{
+    public static class PokeBattlerApiHelper
+    {
+        private static readonly HttpClient pokeBattlerApi = new HttpClient { BaseAddress = new Uri("https://fight.pokebattler.com/") };
+        private static RaidList raidList = new RaidList();
+        private static DateTime raidListExpirationDateTime = DateTime.MinValue;
+
+        public static async Task Initialize()
+        {
+            raidList = await LoadDataFromApi<RaidList>("raids");
+        }
+
+        private static async Task<T> LoadDataFromApi<T>(string route)
+        {
+            using (var response = await pokeBattlerApi.GetAsync(route))
+            {
+                if (response != null && response.IsSuccessStatusCode)
+                {
+                    raidListExpirationDateTime = DateTime.Now.Add(response.Headers.CacheControl.MaxAge ?? TimeSpan.Zero);
+
+                    var jsonString = await response.Content.ReadAsStringAsync();
+                    return JsonConvert.DeserializeObject<T>(jsonString);
+                }
+            }
+
+            return default(T);
+        }
+
+        public static async Task<List<Raid>> GetRaids(int tier)
+        {
+            if (!raidList.Tiers.Any() || raidListExpirationDateTime < DateTime.Now) raidList = await LoadDataFromApi<RaidList>("raids");
+
+            var raidTier = raidList.Tiers.FirstOrDefault(t => t.Name == $"RAID_LEVEL_{tier}");
+
+            return raidTier?.Raids ?? new List<Raid>();
+        }
+    }
+}

--- a/Models/Gym.cs
+++ b/Models/Gym.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace PoGoChatbot.Models
 {
@@ -7,9 +8,9 @@ namespace PoGoChatbot.Models
         [JsonProperty("name")]
         public string Name { get; set; }
         [JsonProperty("aliases")]
-        public string[] Aliases { get; set; } = new string[0];
+        public List<string> Aliases { get; set; } = new List<string>();
         [JsonProperty("territory")]
-        public string[] Territory { get; set; } = new string[0];
+        public List<string> Territory { get; set; } = new List<string>();
         [JsonProperty("description")]
         public string Description { get; set; }
         [JsonProperty("is_ex_eligible")]

--- a/Models/Pokemon.cs
+++ b/Models/Pokemon.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace PoGoChatbot.Models
@@ -11,7 +12,7 @@ namespace PoGoChatbot.Models
         [JsonProperty("pokemon_id")]
         public string Number { get; set; }
         [JsonProperty("type")]
-        public string[] Type { get; set; } = new string[0];
+        public List<string> Type { get; set; } = new List<string>();
 
         public MatchupsForType MatchupsForType { get; set; }
     }

--- a/Models/RaidList.cs
+++ b/Models/RaidList.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PoGoChatbot.Models
+{
+    public class RaidList
+    {
+        [JsonProperty("tiers")]
+        public List<RaidTier> Tiers { get; set; } = new List<RaidTier>();
+    }
+
+    public class TierInfo
+    {
+        [JsonProperty("hp")]
+        public int HP { get; set; }
+        [JsonProperty("cpm")]
+        public double CPM { get; set; }
+        [JsonProperty("level")]
+        public string Level { get; set; }
+        [JsonProperty("eggURL")]
+        public string EggURL { get; set; }
+        [JsonProperty("guessTier")]
+        public string GuessTier { get; set; }
+        [JsonProperty("attackMultiplier")]
+        public double AttackMultiplier { get; set; }
+        [JsonProperty("defenseMultiplier")]
+        public double DefenseMultiplier { get; set; }
+        [JsonProperty("staminaMultiplier")]
+        public double StaminaMultiplier { get; set; }
+    }
+
+    public class RaidTier
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        [JsonProperty("tier")]
+        public string Name { get; set; }
+        [JsonProperty("info")]
+        public TierInfo Info { get; set; }
+        [JsonProperty("raids")]
+        public List<Raid> Raids { get; set; } = new List<Raid>();
+        [JsonProperty("attackMultiplier")]
+        public double AttackMultiplier { get; set; }
+        [JsonProperty("defenseMultiplier")]
+        public double DefenseMultiplier { get; set; }
+        [JsonProperty("staminaMultiplier")]
+        public double StaminaMultiplier { get; set; }
+        [JsonProperty("raidType")]
+        public string RaidType { get; set; }
+    }
+
+    public class Article
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+        [JsonProperty("articleSlug")]
+        public string ArticleSlug { get; set; }
+        [JsonProperty("articleThumbnailURL")]
+        public string ArticleThumbnailURL { get; set; }
+        [JsonProperty("articleURL")]
+        public string ArticleURL { get; set; }
+        [JsonProperty("infographicURL")]
+        public string InfographicURL { get; set; }
+        [JsonProperty("infographicThumbnailURL")]
+        public string InfographicThumbnailURL { get; set; }
+        [JsonProperty("infographicShareURL")]
+        public string InfographicShareURL { get; set; }
+        [JsonProperty("infographicShareWidth")]
+        public int InfographicShareWidth { get; set; }
+        [JsonProperty("infographicShareHeight")]
+        public int InfographicShareHeight { get; set; }
+        [JsonProperty("newsCategorySlug")]
+        public string NewsCategorySlug { get; set; }
+        [JsonProperty("newsTagSlug")]
+        public string NewsTagSlug { get; set; }
+        [JsonProperty("videoId")]
+        public string VideoId { get; set; }
+    }
+
+    public class Raid
+    {
+        [JsonProperty("id")]
+        public object Id { get; set; }
+        [JsonProperty("pokemon")]
+        public string Pokemon { get; set; }
+        [JsonProperty("cp")]
+        public int CP { get; set; }
+        [JsonProperty("shiny")]
+        public bool Shiny { get; set; }
+        [JsonProperty("verified")]
+        public bool Verified { get; set; }
+        [JsonProperty("minCp")]
+        public int MinCP { get; set; }
+        [JsonProperty("article")]
+        public Article Article { get; set; }
+    }
+
+}

--- a/Resources/VariableResources.cs
+++ b/Resources/VariableResources.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace PoGoChatbot
 {
@@ -12,7 +14,7 @@ namespace PoGoChatbot
         // These public variables should have their associated environment variables set on any deployment environment
         public static readonly string GroupMeBotId = Environment.GetEnvironmentVariable("GroupMeBotId") ?? DefaultBotId;
         public static readonly string GroupName = Environment.GetEnvironmentVariable("GroupMeGroupName") ?? DefaultGroupName;
-        public static readonly string[] GymNameExamples = (Environment.GetEnvironmentVariable("GymNameExamples") ?? DefaultGymNameExamples).Split(',');
+        public static readonly List<string> GymNameExamples = (Environment.GetEnvironmentVariable("GymNameExamples") ?? DefaultGymNameExamples).Split(',').ToList();
         public static readonly string WelcomePacketUrl = GetWelcomePacketUrl();
 
         public static string GetMapUrl(string groupName)


### PR DESCRIPTION
This PR adds the ability to consume data from the PokeBattler.com API, so that we can provide enhanced information about current raid bosses. Eventually, this could be used to present an entire menu of the current bosses for each raid tiers natively within the chat - currently, we're still serving up a link to The Silph Road's raid boss list, but supplementing with the PokeBattler infographic(s) for the current Tier Five raid boss(es).